### PR TITLE
Tweak the limiting of momentum to one page

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,7 @@ export default class AyCarousel {
 
       if(this.startIndex !== this.index && this.config.limitMomentumToOnePage) {
         // Limit distance of move to +/- 1 from the startIndex
-        const moveDiff = Math.max(-1, Math.min(1, this.startIndex - this.index));
+        const moveDiff = Math.max(-1, Math.min(1, this.index - this.startIndex));
         this.snap(this.startIndex + moveDiff);
       } else if(delta > stopPoint || delta < -stopPoint) {
         const outOfBoundsLeft = this.target+delta > (this.config.edgeBounceProportion * this.cardWidth);


### PR DESCRIPTION
Limit the distance of the move to +-1 from the startIndex, rather than just snapping to `this.index` when it differs from `this.startIndex`.  Prevents situations when it would sometimes jump more than one index.