### PR TITLE
Allow changing the carousel index

### DIFF
--- a/src/angular1.ts
+++ b/src/angular1.ts
@@ -11,6 +11,7 @@ angular.module(modName, [])
     restrict: 'E',
     scope: {
       config: '=',
+      index: '<?',
       initialIndex: '@',
       onIndexChange: '&',
       onMove: '&'
@@ -23,6 +24,12 @@ angular.module(modName, [])
         carousel.updateItems();
       });
       mutationObserver.observe(el, { childList: true });
+
+      $scope.$watch('index', (newVal) => {
+        let index = parseInt(newVal, 10);
+        carousel.setIndex(index);
+        carousel.snap(index);
+      });
 
       $scope.$on('$destroy', () => {
         mutationObserver.disconnect();


### PR DESCRIPTION
I'm making it optional and also using one way binding since we already have the `onIndexChange`.

When the external index changes I'm doing something similar to the dots click:
https://github.com/AyogoHealth/ay-carousel/blob/48919300bbeb3c460f41d09052c6f32a03e47884/src/index.ts#L336-L340