### PR TITLE
Only cleanup the carousel if it was init'ed

### DIFF
--- a/src/angular1.ts
+++ b/src/angular1.ts
@@ -61,7 +61,9 @@ angular.module(modName, [])
           mutationObserver.disconnect();
         }
 
-        carousel.cleanUp();
+        if (carousel) {
+          carousel.cleanUp();
+        }
       });
     }
   };


### PR DESCRIPTION
Okay, I finally figured out why this weird error was happening in my project!

The answer: the carousel was marked as disabled for desktop-sized resolutions, so it was never initialized. However, the destroy handler would always try to clean it up, leading to an error calling cleanUp() on undefined.